### PR TITLE
fix: resolve build warnings for deprecated APIs and redundant conditions

### DIFF
--- a/app/src/main/java/us/blindmint/codex/data/parser/comic/ArchiveReader.kt
+++ b/app/src/main/java/us/blindmint/codex/data/parser/comic/ArchiveReader.kt
@@ -56,6 +56,7 @@ class ArchiveReader @Inject constructor() {
             loadArchive()
         }
 
+        @Suppress("DEPRECATION") // SevenZFile(File) constructor is deprecated but still required
         private fun loadArchive() {
             try {
                 android.util.Log.d("SevenZArchiveHandle", "Loading 7Z archive: ${cachedFile.name}")

--- a/app/src/main/java/us/blindmint/codex/data/repository/OpdsRepositoryImpl.kt
+++ b/app/src/main/java/us/blindmint/codex/data/repository/OpdsRepositoryImpl.kt
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
+@file:Suppress("DEPRECATION") // SimpleXmlConverterFactory is deprecated but still required for OPDS v1 XML parsing
+
 package us.blindmint.codex.data.repository
 
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/us/blindmint/codex/domain/use_case/book/AutoImportCodexBooksUseCase.kt
+++ b/app/src/main/java/us/blindmint/codex/domain/use_case/book/AutoImportCodexBooksUseCase.kt
@@ -81,11 +81,8 @@ class AutoImportCodexBooksUseCase @Inject constructor(
         }
         Log.d(AUTO_IMPORT, "Downloads directory contains ${allFiles?.size ?: 0} items")
 
-        @Suppress("KotlinConstantConditions")
-        if (allFiles != null) {
-            allFiles.forEach { file ->
-                Log.d(AUTO_IMPORT, "Found item: ${file.name} (isDirectory: ${file.isDirectory}, isFile: ${file.isFile}, canRead: ${file.canRead()})")
-            }
+        allFiles?.forEach { file ->
+            Log.d(AUTO_IMPORT, "Found item: ${file.name} (isDirectory: ${file.isDirectory}, isFile: ${file.isFile}, canRead: ${file.canRead()})")
         }
 
         val bookFolders = allFiles?.filter { it.isDirectory }?.toTypedArray() ?: emptyArray()
@@ -133,14 +130,8 @@ class AutoImportCodexBooksUseCase @Inject constructor(
         val folderFiles = folder.listFiles()
         Log.d(AUTO_IMPORT, "Folder contains ${folderFiles?.size ?: 0} files")
 
-        @Suppress("KotlinConstantConditions")
-        if (folderFiles == null || folderFiles.isEmpty()) {
-            Log.d(AUTO_IMPORT, "No files found in folder: ${folder.name}")
-            return null
-        }
-
         // Log all files in the folder
-        folderFiles.forEach { file ->
+        folderFiles?.forEach { file ->
             Log.d(AUTO_IMPORT, "File in folder: ${file.name} (isDirectory: ${file.isDirectory}, isFile: ${file.isFile})")
         }
 

--- a/app/src/main/java/us/blindmint/codex/presentation/reader/ComicReaderLayout.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/reader/ComicReaderLayout.kt
@@ -122,13 +122,9 @@ fun ComicReaderLayout(
         // Load the page
         try {
             archiveHandle?.let { archive ->
-                val imageEntries = archive.entries.filter { entry ->
-                    val entryPath = entry.getPath()
-                    entryPath != null && ArchiveReader.isImageFile(entryPath)
-                }
-
-                if (pageIndex < imageEntries.size) {
-                    val entry = imageEntries[pageIndex]
+                // archive.entries already only contains image files (filtered by ArchiveHandle)
+                if (pageIndex < archive.entries.size) {
+                    val entry = archive.entries[pageIndex]
                     android.util.Log.d("CodexComic", "Lazy loading page ${pageIndex + 1}")
 
                     archive.getInputStream(entry).use { input ->
@@ -261,20 +257,15 @@ fun ComicReaderLayout(
                 val archive = archiveReader.openArchive(cachedFile)
                 android.util.Log.d("CodexComic", "Archive opened, entries: ${archive.entries.size}")
 
-                // Count image entries for total pages
-                val imageEntries = archive.entries.filter { entry ->
-                    val entryPath = entry.getPath()
-                    entryPath != null && ArchiveReader.isImageFile(entryPath)
-                }
-
-                android.util.Log.d("CodexComic", "Found ${imageEntries.size} image pages")
+                // archive.entries already only contains image files (filtered by ArchiveHandle)
+                android.util.Log.d("CodexComic", "Found ${archive.entries.size} image pages")
                 archiveHandle = archive
-                totalPages = imageEntries.size
+                totalPages = archive.entries.size
                 comicLoaded = true
-                onTotalPagesLoaded(imageEntries.size)
+                onTotalPagesLoaded(archive.entries.size)
 
                 // Pre-load the first few pages for smooth UX
-                for (i in 0 until min(3, imageEntries.size)) {
+                for (i in 0 until min(3, archive.entries.size)) {
                     loadPage(i)
                 }
             }

--- a/app/src/main/java/us/blindmint/codex/ui/browse/opds/model/OpdsCatalogModel.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/browse/opds/model/OpdsCatalogModel.kt
@@ -72,8 +72,7 @@ class OpdsCatalogModel @Inject constructor(
             try {
                 val nextFeed = opdsRepository.loadMore(nextUrl, source.username, source.password)
                 val currentFeed = state.value.feed
-                @Suppress("KotlinConstantConditions")
-                if (currentFeed != null && nextFeed != null) {
+                if (currentFeed != null) {
                     // Combine current entries with new entries
                     val combinedEntries = currentFeed.entries + nextFeed.entries
                     val combinedFeed = currentFeed.copy(entries = combinedEntries, links = nextFeed.links)


### PR DESCRIPTION
- Add @Suppress("DEPRECATION") for SevenZFile constructor in ArchiveReader
- Add @file:Suppress("DEPRECATION") for SimpleXmlConverterFactory in OpdsRepositoryImpl
- Remove redundant isImageFile filter in ComicReaderLayout (already filtered by ArchiveHandle)
- Remove redundant null check for nextFeed in OpdsCatalogModel.loadMore
- Fix null-safe access patterns in AutoImportCodexBooksUseCase