### PR TITLE
feat: improve speed reading UI in book preview and word picker

### DIFF
--- a/app/src/main/java/us/blindmint/codex/presentation/book_info/BookInfoLayoutButton.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/book_info/BookInfoLayoutButton.kt
@@ -94,7 +94,7 @@ fun BookInfoLayoutButton(
             // Visual separator
             Box(
                 modifier = Modifier
-                    .width(1.dp)
+                    .width(2.dp)
                     .fillMaxHeight(0.6f)
                     .background(
                         color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.3f)
@@ -104,7 +104,7 @@ fun BookInfoLayoutButton(
             // Trailing button area
             Box(
                 modifier = Modifier
-                    .size(48.dp)
+                    .size(96.dp)
                     .background(
                         color = MaterialTheme.colorScheme.primary,
                         shape = androidx.compose.foundation.shape.RoundedCornerShape(

--- a/app/src/main/java/us/blindmint/codex/presentation/reader/SpeedReadingWordPickerSheet.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/reader/SpeedReadingWordPickerSheet.kt
@@ -318,7 +318,7 @@ fun SpeedReadingWordPickerSheet(
             HorizontalDivider(color = fontColor.copy(alpha = 0.2f))
             Spacer(modifier = Modifier.height(8.dp))
 
-            // Bottom Row with Cancel, Sentence start checkbox, and Confirm buttons
+            // Bottom Row with Sentence start checkbox, Cancel, and Confirm buttons
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -326,12 +326,6 @@ fun SpeedReadingWordPickerSheet(
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                TextButton(onClick = onDismiss) {
-                    Text("Cancel", color = fontColor)
-                }
-
-                Spacer(modifier = Modifier.weight(1f))
-
                 // Sentence start checkbox
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -346,6 +340,12 @@ fun SpeedReadingWordPickerSheet(
                         style = MaterialTheme.typography.bodyMedium,
                         color = fontColor
                     )
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                TextButton(onClick = onDismiss) {
+                    Text("Cancel", color = fontColor)
                 }
 
                 Spacer(modifier = Modifier.width(8.dp))


### PR DESCRIPTION
- Increase speed reading button size to 2x (96.dp) in book preview
- Make vertical divider thicker (2.dp) for better separation
- Rearrange SpeedReadingWordPickerSheet UI: move Sentence start checkbox to left, Cancel/Confirm buttons to right