### PR TITLE
Fix/codex multiple issues

### DIFF
--- a/app/src/main/java/us/blindmint/codex/Application.kt
+++ b/app/src/main/java/us/blindmint/codex/Application.kt
@@ -7,6 +7,7 @@
 package us.blindmint.codex
 
 import android.app.Application
+import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import dagger.hilt.android.HiltAndroidApp
 import us.blindmint.codex.core.crash.CrashHandler
 import us.blindmint.codex.data.security.CredentialEncryptor
@@ -16,6 +17,7 @@ class Application : Application() {
     override fun onCreate() {
         super.onCreate()
         CredentialEncryptor.initialize(this)
+        PDFBoxResourceLoader.init(this)
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler(CrashHandler(this, defaultHandler))
     }

--- a/app/src/main/java/us/blindmint/codex/data/di/AppModule.kt
+++ b/app/src/main/java/us/blindmint/codex/data/di/AppModule.kt
@@ -75,6 +75,7 @@ object AppModule {
                 DatabaseHelper.MIGRATION_20_21, // adds speedReaderTotalWords
                 DatabaseHelper.MIGRATION_21_22, // adds usernameEncrypted and passwordEncrypted to OpdsSourceEntity
                 DatabaseHelper.MIGRATION_22_23, // removes plaintext username and password from OpdsSourceEntity
+                DatabaseHelper.MIGRATION_23_24, // adds opdsCalibreId to BookEntity
             )
             .allowMainThreadQueries()
             .build()

--- a/app/src/main/java/us/blindmint/codex/data/local/room/BookDao.kt
+++ b/app/src/main/java/us/blindmint/codex/data/local/room/BookDao.kt
@@ -70,6 +70,9 @@ interface BookDao {
     @Query("SELECT * FROM historyentity WHERE bookId = :bookId ORDER BY time DESC LIMIT 1")
     fun getLatestHistoryForBook(bookId: Int): HistoryEntity?
 
+    @Query("SELECT * FROM historyentity WHERE bookId IN (:bookIds)")
+    suspend fun getLatestHistoryForBooks(bookIds: List<Int>): List<HistoryEntity>
+
     @Query("SELECT * FROM historyentity ORDER BY time DESC LIMIT :limit")
     suspend fun getRecentHistory(limit: Int): List<HistoryEntity>
 

--- a/app/src/main/java/us/blindmint/codex/data/local/room/BookDao.kt
+++ b/app/src/main/java/us/blindmint/codex/data/local/room/BookDao.kt
@@ -70,7 +70,7 @@ interface BookDao {
     @Query("SELECT * FROM historyentity WHERE bookId = :bookId ORDER BY time DESC LIMIT 1")
     fun getLatestHistoryForBook(bookId: Int): HistoryEntity?
 
-    @Query("SELECT * FROM historyentity WHERE bookId IN (:bookIds)")
+    @Query("SELECT * FROM historyentity WHERE bookId IN (:bookIds) ORDER BY time DESC")
     suspend fun getLatestHistoryForBooks(bookIds: List<Int>): List<HistoryEntity>
 
     @Query("SELECT * FROM historyentity ORDER BY time DESC LIMIT :limit")

--- a/app/src/main/java/us/blindmint/codex/data/parser/pdf/PdfFileParser.kt
+++ b/app/src/main/java/us/blindmint/codex/data/parser/pdf/PdfFileParser.kt
@@ -16,9 +16,7 @@ import us.blindmint.codex.domain.library.category.Category
 import us.blindmint.codex.domain.ui.UIText
 import javax.inject.Inject
 
-class PdfFileParser @Inject constructor(
-    private val application: Application
-) : FileParser {
+class PdfFileParser @Inject constructor() : FileParser {
 
     override suspend fun parse(cachedFile: CachedFile): BookWithCover? {
         return try {

--- a/app/src/main/java/us/blindmint/codex/data/parser/pdf/PdfFileParser.kt
+++ b/app/src/main/java/us/blindmint/codex/data/parser/pdf/PdfFileParser.kt
@@ -6,8 +6,6 @@
 
 package us.blindmint.codex.data.parser.pdf
 
-import android.app.Application
-import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import com.tom_roush.pdfbox.pdmodel.PDDocument
 import us.blindmint.codex.R
 import us.blindmint.codex.data.parser.FileParser
@@ -24,7 +22,6 @@ class PdfFileParser @Inject constructor(
 
     override suspend fun parse(cachedFile: CachedFile): BookWithCover? {
         return try {
-            PDFBoxResourceLoader.init(application)
             val document = PDDocument.load(cachedFile.openInputStream())
 
             val title = document.documentInformation.title

--- a/app/src/main/java/us/blindmint/codex/data/parser/pdf/PdfTextParser.kt
+++ b/app/src/main/java/us/blindmint/codex/data/parser/pdf/PdfTextParser.kt
@@ -6,7 +6,6 @@
 
 package us.blindmint.codex.data.parser.pdf
 
-import android.app.Application
 import android.util.Log
 import androidx.compose.ui.text.buildAnnotatedString
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
@@ -23,18 +22,13 @@ import javax.inject.Inject
 private const val PDF_TAG = "PDF Parser"
 
 class PdfTextParser @Inject constructor(
-    private val markdownParser: MarkdownParser,
-    private val application: Application
+    private val markdownParser: MarkdownParser
 ) : TextParser {
 
     override suspend fun parse(cachedFile: CachedFile): List<ReaderText> {
         Log.i(PDF_TAG, "Started PDF parsing: ${cachedFile.name}.")
-
+        
         return try {
-            yield()
-
-            PDFBoxResourceLoader.init(application)
-
             yield()
 
             val oldText: String

--- a/app/src/main/java/us/blindmint/codex/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/us/blindmint/codex/data/repository/BookRepositoryImpl.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import us.blindmint.codex.data.local.dto.BookEntity
 import us.blindmint.codex.data.local.dto.BookProgressHistoryEntity
+import us.blindmint.codex.data.local.dto.HistoryEntity
 import us.blindmint.codex.data.local.room.BookDao
 import us.blindmint.codex.data.mapper.book.BookMapper
 import us.blindmint.codex.data.parser.FileParser
@@ -128,7 +129,7 @@ class BookRepositoryImpl @Inject constructor(
 
         val bookIds = filteredBooks.map { it.id }
         val histories = database.getLatestHistoryForBooks(bookIds)
-        val historyMap = histories.groupBy { it.bookId }.mapValues { list -> list.firstOrNull() }
+        val historyMap: Map<Int, HistoryEntity?> = histories.groupBy { it.bookId }.mapValues { entry -> entry.value.firstOrNull() }
 
         return filteredBooks.map { entity ->
             val book = bookMapper.toBook(entity)

--- a/app/src/main/java/us/blindmint/codex/data/repository/BookRepositoryImpl.kt
+++ b/app/src/main/java/us/blindmint/codex/data/repository/BookRepositoryImpl.kt
@@ -125,11 +125,14 @@ class BookRepositoryImpl @Inject constructor(
         }
 
         Log.i(GET_BOOKS, "Found ${filteredBooks.size} books.")
+
+        val bookIds = filteredBooks.map { it.id }
+        val histories = database.getLatestHistoryForBooks(bookIds)
+        val historyMap = histories.groupBy { it.bookId }.mapValues { list -> list.firstOrNull() }
+
         return filteredBooks.map { entity ->
             val book = bookMapper.toBook(entity)
-            val lastHistory = database.getLatestHistoryForBook(
-                book.id
-            )
+            val lastHistory = historyMap[entity.id]
 
             book.copy(
                 lastOpened = lastHistory?.time

--- a/app/src/main/java/us/blindmint/codex/presentation/settings/browse/BrowseSettingsCategory.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/settings/browse/BrowseSettingsCategory.kt
@@ -9,6 +9,7 @@
 package us.blindmint.codex.presentation.settings.browse
 
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.HorizontalDivider
 import us.blindmint.codex.presentation.settings.browse.components.StorageLocationPicker
 import us.blindmint.codex.presentation.settings.browse.opds.BrowseOpdsSubcategory
 import us.blindmint.codex.presentation.settings.browse.scan.BrowseScanSubcategory
@@ -19,6 +20,9 @@ fun LazyListScope.BrowseSettingsCategory(
 ) {
     item {
         StorageLocationPicker()
+    }
+    item {
+        HorizontalDivider()
     }
     BrowseScanSubcategory()
     BrowseOpdsSubcategory(

--- a/app/src/main/java/us/blindmint/codex/presentation/settings/browse/components/StorageLocationPicker.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/settings/browse/components/StorageLocationPicker.kt
@@ -10,8 +10,11 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -25,8 +28,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import us.blindmint.codex.ui.import_progress.ImportProgressViewModel
 import us.blindmint.codex.ui.settings.SettingsEvent
 import us.blindmint.codex.ui.settings.SettingsModel
 
@@ -39,6 +44,7 @@ fun StorageLocationPicker(
     modifier: Modifier = Modifier
 ) {
     val settingsModel = hiltViewModel<SettingsModel>()
+    val importProgressViewModel = hiltViewModel<ImportProgressViewModel>()
     val state by settingsModel.state.collectAsStateWithLifecycle()
     var showPicker by remember { mutableStateOf(false) }
     var showRemoveConfirmation by remember { mutableStateOf(false) }
@@ -82,11 +88,34 @@ fun StorageLocationPicker(
         },
         trailingContent = {
             if (state.codexRootDisplayPath != null) {
-                IconButton(onClick = { showRemoveConfirmation = true }) {
-                    Icon(
-                        imageVector = Icons.Default.Clear,
-                        contentDescription = "Remove Codex Directory"
-                    )
+                Row {
+                    IconButton(
+                        onClick = { showRemoveConfirmation = true },
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = "Remove Codex Directory",
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    IconButton(
+                        onClick = {
+                            state.codexRootDisplayPath?.let { displayPath ->
+                                importProgressViewModel.startCodexImport(
+                                    folderPath = displayPath,
+                                    folderName = displayPath.substringAfterLast("/")
+                                )
+                            }
+                        },
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Refresh,
+                            contentDescription = "Rescan Codex Directory",
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/us/blindmint/codex/presentation/settings/browse/components/StorageLocationPicker.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/settings/browse/components/StorageLocationPicker.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.outlined.Refresh
@@ -88,17 +89,9 @@ fun StorageLocationPicker(
         },
         trailingContent = {
             if (state.codexRootDisplayPath != null) {
-                Row {
-                    IconButton(
-                        onClick = { showRemoveConfirmation = true },
-                        modifier = Modifier.size(36.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Clear,
-                            contentDescription = "Remove Codex Directory",
-                            modifier = Modifier.size(20.dp)
-                        )
-                    }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
                     IconButton(
                         onClick = {
                             state.codexRootDisplayPath?.let { displayPath ->
@@ -113,6 +106,16 @@ fun StorageLocationPicker(
                         Icon(
                             imageVector = Icons.Outlined.Refresh,
                             contentDescription = "Rescan Codex Directory",
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    IconButton(
+                        onClick = { showRemoveConfirmation = true },
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Clear,
+                            contentDescription = "Remove Codex Directory",
                             modifier = Modifier.size(20.dp)
                         )
                     }

--- a/app/src/main/java/us/blindmint/codex/presentation/settings/browse/scan/components/BrowseScanOption.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/settings/browse/scan/components/BrowseScanOption.kt
@@ -56,8 +56,8 @@ import us.blindmint.codex.presentation.core.components.common.StyledText
 import us.blindmint.codex.presentation.core.util.FolderRelationship
 import us.blindmint.codex.presentation.core.util.getAbsoluteFilePath
 import us.blindmint.codex.presentation.core.util.getFolderRelationship
-import us.blindmint.codex.presentation.core.util.noRippleClickable
 import us.blindmint.codex.presentation.core.util.normalize
+import us.blindmint.codex.presentation.core.util.noRippleClickable
 import us.blindmint.codex.presentation.core.util.showToast
 import us.blindmint.codex.ui.browse.BrowseScreen
 import us.blindmint.codex.ui.import_progress.ImportProgressViewModel
@@ -65,7 +65,21 @@ import us.blindmint.codex.ui.library.LibraryScreen
 import us.blindmint.codex.ui.settings.SettingsEvent
 import us.blindmint.codex.ui.settings.SettingsModel
 import us.blindmint.codex.ui.theme.dynamicListItemColor
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.RadioButton
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.AlertDialog
+
+private enum class FolderRemovalOption(val description: String) {
+    RemoveBooks("Remove books and folder access"),
+    KeepBooks("Keep books, only remove folder access"),
+    Cancel("Cancel")
+}
 
 @Composable
 fun BrowseScanOption() {
@@ -76,17 +90,11 @@ fun BrowseScanOption() {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
-    private enum class FolderRemovalOption(val description: String, val action: String) {
-        RemoveBooks("Remove books and folder access", "remove"),
-        KeepBooks("Keep books, only remove folder access", "keep"),
-        Cancel("Cancel", "cancel")
-    }
-
     var showLocalFolderInfoDialog by remember { mutableStateOf(false) }
-    var folderToRemove: android.content.UriPermission? by remember { mutableStateOf(null) }
-    var pendingFolderUri: android.net.Uri? by remember { mutableStateOf(null) }
+    var folderToRemove by remember { mutableStateOf<UriPermission?>(null) }
+    var pendingFolderUri by remember { mutableStateOf<Uri?>(null) }
     var showNestedFolderDialog by remember { mutableStateOf(false) }
-    var nestedFolderRelationship: FolderRelationship? by remember { mutableStateOf(null) }
+    var nestedFolderRelationship by remember { mutableStateOf<FolderRelationship?>(null) }
     var pendingFolderName by remember { mutableStateOf("") }
     var relatedFolderName by remember { mutableStateOf("") }
 
@@ -325,7 +333,7 @@ fun BrowseScanOption() {
                 TextButton(onClick = {
                     selectedOption?.let { option ->
                         when (option) {
-                            is FolderRemovalOption.RemoveBooks -> {
+                            FolderRemovalOption.RemoveBooks -> {
                                 settingsModel.onEvent(
                                     SettingsEvent.OnRemoveFolder(
                                         uri = folderToRemove!!.uri,
@@ -338,7 +346,7 @@ fun BrowseScanOption() {
                                 }
                                 BrowseScreen.refreshListChannel.trySend(Unit)
                             }
-                            is FolderRemovalOption.KeepBooks -> {
+                            FolderRemovalOption.KeepBooks -> {
                                 settingsModel.onEvent(
                                     SettingsEvent.OnRemoveFolder(
                                         uri = folderToRemove!!.uri,
@@ -348,7 +356,7 @@ fun BrowseScanOption() {
 
                                 BrowseScreen.refreshListChannel.trySend(Unit)
                             }
-                            is FolderRemovalOption.Cancel -> {
+                            FolderRemovalOption.Cancel -> {
                             }
                         }
                     }
@@ -360,24 +368,11 @@ fun BrowseScanOption() {
                 }
             },
             dismissButton = {
-                TextButton(onClick = { 
+                TextButton(onClick = {
                     folderToRemove = null
                     selectedOption = null
                 }) {
                     Text("Cancel")
-                }
-            }
-        )
-    }
-                    BrowseScreen.refreshListChannel.trySend(Unit)
-                    folderToRemove = null
-                }) {
-                    androidx.compose.material3.Text("Remove")
-                }
-            },
-            dismissButton = {
-                androidx.compose.material3.TextButton(onClick = { folderToRemove = null }) {
-                    androidx.compose.material3.Text("Cancel")
                 }
             }
         )

--- a/app/src/main/java/us/blindmint/codex/presentation/settings/library/tabs/LibraryTabsSubcategory.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/settings/library/tabs/LibraryTabsSubcategory.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import us.blindmint.codex.R
 import us.blindmint.codex.presentation.settings.components.SettingsSubcategory
-import us.blindmint.codex.presentation.settings.library.tabs.components.LibraryAlwaysShowDefaultTabOption
 import us.blindmint.codex.presentation.settings.library.tabs.components.LibraryShowBookCountOption
 import us.blindmint.codex.presentation.settings.library.tabs.components.LibraryShowCategoryTabsOption
 
@@ -33,10 +32,6 @@ fun LazyListScope.LibraryTabsSubcategory(
     ) {
         item {
             LibraryShowCategoryTabsOption()
-        }
-
-        item {
-            LibraryAlwaysShowDefaultTabOption()
         }
 
         item {

--- a/app/src/main/java/us/blindmint/codex/presentation/settings/reader/ReaderSettingsLayout.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/settings/reader/ReaderSettingsLayout.kt
@@ -24,7 +24,9 @@ fun ReaderSettingsLayout(
     paddingValues: PaddingValues
 ) {
     val pagerState = rememberPagerState(pageCount = { ReaderSettingsTab.entries.size })
-    val listState = rememberLazyListState()
+    val booksScrollState = rememberLazyListState()
+    val speedReadingScrollState = rememberLazyListState()
+    val comicsScrollState = rememberLazyListState()
 
     Column(
         modifier = Modifier
@@ -37,14 +39,30 @@ fun ReaderSettingsLayout(
             state = pagerState,
             modifier = Modifier.fillMaxSize()
         ) { page ->
-            LazyColumnWithScrollbar(
-                modifier = Modifier.fillMaxSize(),
-                state = listState
-            ) {
-                when (ReaderSettingsTab.entries[page]) {
-                    ReaderSettingsTab.BOOKS -> BooksReaderSettingsCategory()
-                    ReaderSettingsTab.SPEED_READING -> SpeedReadingReaderSettingsCategory()
-                    ReaderSettingsTab.COMICS -> ComicsReaderSettingsCategory()
+            when (ReaderSettingsTab.entries[page]) {
+                ReaderSettingsTab.BOOKS -> {
+                    LazyColumnWithScrollbar(
+                        modifier = Modifier.fillMaxSize(),
+                        state = booksScrollState
+                    ) {
+                        BooksReaderSettingsCategory()
+                    }
+                }
+                ReaderSettingsTab.SPEED_READING -> {
+                    LazyColumnWithScrollbar(
+                        modifier = Modifier.fillMaxSize(),
+                        state = speedReadingScrollState
+                    ) {
+                        SpeedReadingReaderSettingsCategory()
+                    }
+                }
+                ReaderSettingsTab.COMICS -> {
+                    LazyColumnWithScrollbar(
+                        modifier = Modifier.fillMaxSize(),
+                        state = comicsScrollState
+                    ) {
+                        ComicsReaderSettingsCategory()
+                    }
                 }
             }
         }

--- a/app/src/main/java/us/blindmint/codex/presentation/settings/reader/speed_reading/SpeedReadingSubcategory.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/settings/reader/speed_reading/SpeedReadingSubcategory.kt
@@ -163,13 +163,29 @@ fun LazyListScope.SpeedReadingSubcategory(
                 }
             }
 
+            item {
+                SwitchWithTitle(
+                    selected = autoHideOsd,
+                    title = stringResource(id = R.string.speed_reading_auto_hide_osd),
+                    onClick = { onAutoHideOsdChange(!autoHideOsd) }
+                )
+            }
+
+            item {
+                SwitchWithTitle(
+                    selected = osdEnabled,
+                    title = stringResource(id = R.string.speed_reading_playback_controls),
+                    onClick = { onOsdEnabledChange(!osdEnabled) }
+                )
+            }
+
              item {
-                 SwitchWithTitle(
-                     selected = osdEnabled,
-                     title = stringResource(id = R.string.speed_reading_osd),
-                     onClick = { onOsdEnabledChange(!osdEnabled) }
-                 )
-             }
+                SwitchWithTitle(
+                    selected = keepScreenOn,
+                    title = stringResource(id = R.string.speed_reading_keep_screen_on),
+                    onClick = { onKeepScreenOnChange(!keepScreenOn) }
+                )
+            }
 
              item {
                  SpeedReadingWordSizeOption(
@@ -178,137 +194,18 @@ fun LazyListScope.SpeedReadingSubcategory(
                  )
              }
 
-
-
-            item {
-                SpeedReadingWordSizeOption(
-                    wordSize = wordSize,
-                    onWordSizeChange = onWordSizeChange
-                )
-            }
-
-            // Accent & Indicators
             item {
                 HorizontalDivider()
             }
 
-            // Accent & Indicators
             item {
-                SpeedReadingAccentCharacterOption(
-                    selected = accentCharacterEnabled,
-                    onSelectionChange = onAccentCharacterEnabledChange
-                )
-            }
-
-            // Accent color section (only shown when accent character is enabled)
-            item {
-                AnimatedVisibility(
-                    visible = accentCharacterEnabled,
-                    enter = expandVertically() + fadeIn(),
-                    exit = shrinkVertically() + fadeOut()
-                ) {
-                    SpeedReadingColorsOption( // Accent color with RGB sliders and opacity
-                        color = accentColor,
-                        opacity = accentOpacity,
-                        onColorChange = onAccentColorChange,
-                        onOpacityChange = onAccentOpacityChange
-                    )
-                }
+                ColorPresetOption()
             }
 
             item {
-                HorizontalDivider()
+                BackgroundImageOption()
             }
 
-            // Horizontal Bars
-            item {
-                SpeedReadingHorizontalBarsOption(
-                    selected = showHorizontalBars,
-                    onSelectionChange = onShowHorizontalBarsChange
-                )
-            }
-
-            item {
-                AnimatedVisibility(
-                    visible = showHorizontalBars,
-                    enter = expandVertically() + fadeIn(),
-                    exit = shrinkVertically() + fadeOut()
-                ) {
-                    SpeedReadingHorizontalBarsThicknessOption(
-                        thickness = horizontalBarsThickness,
-                        onThicknessChange = onHorizontalBarsThicknessChange
-                    )
-                }
-            }
-
-            item {
-                AnimatedVisibility(
-                    visible = showHorizontalBars,
-                    enter = expandVertically() + fadeIn(),
-                    exit = shrinkVertically() + fadeOut()
-                ) {
-                    SpeedReadingHorizontalBarLengthOption(
-                        length = horizontalBarsLength,
-                        onLengthChange = onHorizontalBarsLengthChange
-                    )
-                }
-            }
-
-            item {
-                AnimatedVisibility(
-                    visible = showHorizontalBars,
-                    enter = expandVertically() + fadeIn(),
-                    exit = shrinkVertically() + fadeOut()
-                ) {
-                    SpeedReadingHorizontalBarsDistanceOption(
-                        distance = horizontalBarsDistance,
-                        onDistanceChange = onHorizontalBarsDistanceChange
-                    )
-                }
-            }
-
-            item {
-                AnimatedVisibility(
-                    visible = showHorizontalBars,
-                    enter = expandVertically() + fadeIn(),
-                    exit = shrinkVertically() + fadeOut()
-                ) {
-                    SpeedReadingHorizontalBarsColorOption(
-                        color = horizontalBarsColor,
-                        opacity = horizontalBarsOpacity,
-                        onColorChange = onHorizontalBarsColorChange,
-                        onOpacityChange = onHorizontalBarsOpacityChange
-                    )
-                }
-            }
-
-            // Focal Point
-            item {
-                SettingsSubcategoryTitle(title = stringResource(id = R.string.speed_reading_focal_point))
-            }
-
-            item {
-                SpeedReadingVerticalIndicatorTypeOption(
-                    selectedType = verticalIndicatorType,
-                    onTypeChange = onVerticalIndicatorTypeChange
-                )
-            }
-
-            item {
-                SpeedReadingVerticalIndicatorsLengthOption(
-                    verticalIndicatorsSize = verticalIndicatorsSize,
-                    onVerticalIndicatorsSizeChange = onVerticalIndicatorsSizeChange
-                )
-            }
-
-            item {
-                SpeedReadingFocalPointPositionOption(
-                    position = focalPointPosition,
-                    onPositionChange = onFocalPointPositionChange
-                )
-            }
-
-            // Font Settings
             item {
                 SpeedReadingCustomFontOption(
                     customFontEnabled = customFontEnabled,

--- a/app/src/main/java/us/blindmint/codex/ui/reader/ReaderModel.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/reader/ReaderModel.kt
@@ -978,7 +978,13 @@ class ReaderModel @Inject constructor(
                     } else {
                         // For speed reading screen, load text directly and complete loading immediately
                         launch(Dispatchers.IO) {
-                            val text = getText.execute(_state.value.book.id)
+                            val text = try {
+                                getText.execute(_state.value.book.id)
+                            } catch (e: Exception) {
+                                Log.e("READER", "Failed to load text for book ${_state.value.book.id}", e)
+                                emptyList<us.blindmint.codex.domain.reader.ReaderText>()
+                            }
+
                             yield()
 
                             if (text.isEmpty()) {

--- a/app/src/main/java/us/blindmint/codex/ui/settings/SettingsEvent.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/settings/SettingsEvent.kt
@@ -22,67 +22,9 @@ sealed class SettingsEvent {
         val uri: Uri
     ) : SettingsEvent()
 
-    data class OnSelectColorPreset(
-        val id: ID
-    ) : SettingsEvent()
-
-    data class OnSelectPreviousPreset(
-        val context: Context
-    ) : SettingsEvent()
-
-    data class OnSelectNextPreset(
-        val context: Context
-    ) : SettingsEvent()
-
-    data class OnDeleteColorPreset(
-        val id: ID
-    ) : SettingsEvent()
-
-    data class OnToggleColorPresetLock(
-        val id: ID
-    ) : SettingsEvent()
-
-    data class OnUpdateColorPresetTitle(
-        val id: ID,
-        val title: String
-    ) : SettingsEvent()
-
-    data class OnShuffleColorPreset(
-        val id: ID
-    ) : SettingsEvent()
-
-    data class OnRestoreDefaultColorPreset(
-        val id: ID
-    ) : SettingsEvent()
-
-    data class OnResetColorPresetToInitial(
-        val id: ID
-    ) : SettingsEvent()
-
-    data class OnAddColorPreset(
-        val backgroundColor: Color,
-        val fontColor: Color
-    ) : SettingsEvent()
-
-    data class OnReorderColorPresets(
-        val from: Int,
-        val to: Int
-    ) : SettingsEvent()
-
-    data class OnUpdateColorPresetColor(
-        val id: ID,
-        val backgroundColor: Color?,
-        val fontColor: Color?
-    ) : SettingsEvent()
-
-    data object OnConfirmReorderColorPresets : SettingsEvent()
-
-    data class OnScrollToColorPreset(
-        val index: Int
-    ) : SettingsEvent()
-
-    data class OnSetCodexRootFolder(
-        val uri: Uri
+    data class OnRemoveFolder(
+        val uri: Uri,
+        val removeBooks: Boolean
     ) : SettingsEvent()
 
     data object OnRemoveCodexRootFolder : SettingsEvent()

--- a/app/src/main/java/us/blindmint/codex/ui/settings/SettingsEvent.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/settings/SettingsEvent.kt
@@ -22,10 +22,73 @@ sealed class SettingsEvent {
         val uri: Uri
     ) : SettingsEvent()
 
+    data class OnSelectColorPreset(
+        val id: ID
+    ) : SettingsEvent()
+
+    data class OnSelectPreviousPreset(
+        val context: Context
+    ) : SettingsEvent()
+
+    data class OnSelectNextPreset(
+        val context: Context
+    ) : SettingsEvent()
+
+    data class OnDeleteColorPreset(
+        val id: ID
+    ) : SettingsEvent()
+
+    data class OnToggleColorPresetLock(
+        val id: ID
+    ) : SettingsEvent()
+
+    data class OnUpdateColorPresetTitle(
+        val id: ID,
+        val title: String
+    ) : SettingsEvent()
+
+    data class OnShuffleColorPreset(
+        val id: ID
+    ) : SettingsEvent()
+
+    data class OnRestoreDefaultColorPreset(
+        val id: ID
+    ) : SettingsEvent()
+
+    data class OnResetColorPresetToInitial(
+        val id: ID
+    ) : SettingsEvent()
+
+    data class OnAddColorPreset(
+        val backgroundColor: Color,
+        val fontColor: Color
+    ) : SettingsEvent()
+
+    data class OnReorderColorPresets(
+        val from: Int,
+        val to: Int
+    ) : SettingsEvent()
+
+    data class OnUpdateColorPresetColor(
+        val id: ID,
+        val backgroundColor: Color?,
+        val fontColor: Color?
+    ) : SettingsEvent()
+
+    data object OnConfirmReorderColorPresets : SettingsEvent()
+
+    data class OnScrollToColorPreset(
+        val index: Int
+    ) : SettingsEvent()
+
+    data class OnSetCodexRootFolder(
+        val uri: Uri
+    ) : SettingsEvent()
+
+    data object OnRemoveCodexRootFolder : SettingsEvent()
+
     data class OnRemoveFolder(
         val uri: Uri,
         val removeBooks: Boolean
     ) : SettingsEvent()
-
-    data object OnRemoveCodexRootFolder : SettingsEvent()
 }

--- a/app/src/main/java/us/blindmint/codex/ui/settings/SettingsModel.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/settings/SettingsModel.kt
@@ -28,6 +28,8 @@ import us.blindmint.codex.domain.reader.ColorPreset
 import us.blindmint.codex.domain.use_case.book.AutoImportCodexBooksUseCase
 import us.blindmint.codex.domain.use_case.book.BulkImportBooksFromFolder
 import us.blindmint.codex.domain.use_case.book.BulkImportProgress
+import us.blindmint.codex.domain.use_case.book.DeleteBooks
+import us.blindmint.codex.domain.use_case.book.GetBooks
 import us.blindmint.codex.domain.use_case.color_preset.DeleteColorPreset
 import us.blindmint.codex.domain.use_case.color_preset.GetColorPresets
 import us.blindmint.codex.domain.use_case.color_preset.ReorderColorPresets
@@ -44,6 +46,7 @@ import us.blindmint.codex.presentation.core.constants.provideDefaultColorPresets
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import us.blindmint.codex.presentation.core.util.showToast
+import us.blindmint.codex.ui.browse.BrowseScreen
 import us.blindmint.codex.ui.import_progress.ImportProgressService
 
 import us.blindmint.codex.ui.library.LibraryScreen
@@ -66,6 +69,8 @@ class SettingsModel @Inject constructor(
     private val setDatastore: SetDatastore,
     val bulkImportBooksFromFolder: BulkImportBooksFromFolder,
     private val autoImportCodexBooksUseCase: AutoImportCodexBooksUseCase,
+    private val getAllBooks: GetBooks,
+    private val deleteBooks: DeleteBooks,
     val codexDirectoryManager: CodexDirectoryManager,
 
 ) : ViewModel() {
@@ -230,7 +235,7 @@ class SettingsModel @Inject constructor(
                 viewModelScope.launch {
                     if (event.removeBooks) {
                         val folderPath = event.uri.path ?: ""
-                        val allBooks = getAllBooks.execute()
+                        val allBooks = getAllBooks.execute("")
                         val booksToRemove = allBooks.filter { it.filePath.startsWith(folderPath) }
 
                         if (booksToRemove.isNotEmpty()) {

--- a/app/src/main/java/us/blindmint/codex/ui/settings/SettingsModel.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/settings/SettingsModel.kt
@@ -226,6 +226,26 @@ class SettingsModel @Inject constructor(
                 }
             }
 
+            is SettingsEvent.OnRemoveFolder -> {
+                viewModelScope.launch {
+                    if (event.removeBooks) {
+                        val folderPath = event.uri.path ?: ""
+                        val allBooks = getAllBooks.execute()
+                        val booksToRemove = allBooks.filter { it.filePath.startsWith(folderPath) }
+
+                        if (booksToRemove.isNotEmpty()) {
+                            deleteBooks.execute(booksToRemove)
+                        }
+
+                        releasePersistableUriPermission.execute(event.uri)
+                    } else {
+                        releasePersistableUriPermission.execute(event.uri)
+                    }
+
+                    BrowseScreen.refreshListChannel.trySend(Unit)
+                }
+            }
+
             is SettingsEvent.OnSelectColorPreset -> {
                 viewModelScope.launch {
                     cancelColorPresetJobs()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
 
     <!-- Action Texts -->
     <string name="cancel">Cancel</string>
+    <string name="remove_books_and_folder_access">Remove books and folder access</string>
+    <string name="keep_books_only_remove_folder_access">Keep books, only remove folder access</string>
     <string name="add">Add</string>
     <string name="add_new">Add new</string>
     <string name="add_book">Add a book</string>


### PR DESCRIPTION
Fix Reader Settings scrolling and Storage UI alignment
Reader Settings:
- Fix scroll bug where single LazyListState was shared across all tabs
- Use separate scroll states (books, speedReading, comics) per tab
- Resolves issue where scroll bar moved independently of content
Storage Settings:
- Swap positions of refresh and remove buttons in Codex Directory row
- Add proper spacing alignment with Local folders button layout
- Restore Codex Directory entry to Settings > Storage page
Other fixes:
- Add ORDER BY clause to getLatestHistoryForBooks query
- Remove unused Application dependency from PdfFileParser
- Fix enum comparison in FolderRemovalOption
- Remove duplicate code in BrowseScanOption