### PR TITLE
Fix crash when accessing deleted files in book details

### DIFF
--- a/app/src/main/java/us/blindmint/codex/domain/file/CachedFile.kt
+++ b/app/src/main/java/us/blindmint/codex/domain/file/CachedFile.kt
@@ -221,12 +221,12 @@ class CachedFile(
             )
         }
 
-        context.contentResolver.query(
-            uri,
-            projection.toTypedArray(),
-            null, null, null
-        )?.use { cursor ->
-            try {
+        try {
+            context.contentResolver.query(
+                uri,
+                projection.toTypedArray(),
+                null, null, null
+            )?.use { cursor ->
                 if (cursor.moveToFirst()) {
                     val queryResult = mutableMapOf<String, Any?>()
 
@@ -291,9 +291,9 @@ class CachedFile(
                         isDirectory = isDirectoryQuery
                     )
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
             }
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
 
         return QueryParams(


### PR DESCRIPTION
- Wrap ContentResolver.query() in try-catch to handle FileNotFoundException
- Prevents app crash when OPDS downloaded files are deleted
- Returns fallback values (unknown filename, size=0) for missing files
- Gracefully handles ContentResolver exceptions