### PR TITLE
fix: preserve smart quotes in speed reader display

### DIFF
--- a/app/src/main/java/us/blindmint/codex/data/parser/SpeedReaderWordExtractor.kt
+++ b/app/src/main/java/us/blindmint/codex/data/parser/SpeedReaderWordExtractor.kt
@@ -150,16 +150,21 @@ object SpeedReaderWordExtractor {
                     char.isWhitespace() -> Unit
                     else -> {
                         val isPunctuation = char == '.' ||
-                                          char == ',' ||
-                                          char == ';' ||
-                                          char == ':' ||
-                                          char == '!' ||
-                                          char == '?' ||
-                                          char == '"' ||
-                                          char == '\'' ||
-                                          char == '-' ||
-                                          char == '—' ||
-                                          char == '…'
+                            char == ',' ||
+                            char == ';' ||
+                            char == ':' ||
+                            char == '!' ||
+                            char == '?' ||
+                            char == '"' ||
+                            char == '\'' ||
+                            char == '-' ||
+                            char == '—' ||
+                            char == '…' ||
+                            // Smart quotes (curly quotes used in books)
+                            char == '\u201C' ||
+                            char == '\u201D' ||
+                            char == '\u2018' ||
+                            char == '\u2019'
 
                         if (isPunctuation) append(char)
                     }

--- a/app/src/main/java/us/blindmint/codex/presentation/reader/SpeedReadingContent.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/reader/SpeedReadingContent.kt
@@ -822,8 +822,8 @@ fun SpeedReadingContent(
 fun findAccentCharIndex(word: String): Int {
     if (word.isEmpty()) return -1
 
-    // Strip punctuation for calculation
-    val cleanWord = word.trimEnd { it in ".,!?;:'\"-" }
+    // Strip punctuation for calculation (including smart quotes)
+    val cleanWord = word.trimEnd { it in ".,!?;:'\"-\u201C\u201D\u2018\u2019" }
     if (cleanWord.isEmpty()) return 0
 
     // Extended vowel set for multiple languages including accented characters


### PR DESCRIPTION
Books use curly quotes (\u201C, \u201D, \u2018, \u2019) which were being stripped during word tokenization. Now both cleanWordForSpeedReader() and findAccentCharIndex() preserve all quote types, so dialogue indicators display correctly in RSVP mode.