### PR TITLE
Fix reader progress not restored on cold start

### DIFF
--- a/app/src/main/java/us/blindmint/codex/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/reader/ReaderScreen.kt
@@ -8,6 +8,7 @@ package us.blindmint.codex.ui.reader
 
 import android.content.pm.ActivityInfo
 import android.os.Parcelable
+import android.util.Log
 import android.view.WindowManager
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -469,6 +470,19 @@ data class ReaderScreen(
         }
         LaunchedEffect(listState) {
             screenModel.updateProgress(listState)
+        }
+
+        // Restore scroll position when text is loaded and initialScrollIndex is set
+        LaunchedEffect(state.value.text, state.value.initialScrollIndex) {
+            if (state.value.text.isNotEmpty() && state.value.initialScrollIndex >= 0) {
+                Log.d("READER", "UI restoring scroll position: index=${state.value.initialScrollIndex}, offset=${state.value.initialScrollOffset}")
+                listState.requestScrollToItem(
+                    state.value.initialScrollIndex,
+                    state.value.initialScrollOffset
+                )
+                // Update the chapter after scrolling
+                screenModel.updateChapter(index = state.value.initialScrollIndex)
+            }
         }
 
         DisposableEffect(mainState.value.screenOrientation) {

--- a/app/src/main/java/us/blindmint/codex/ui/reader/ReaderState.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/reader/ReaderState.kt
@@ -59,5 +59,9 @@ data class ReaderState(
 
     // Comic navigation
     val currentComicPage: Int = 0,
-    val totalComicPages: Int = 0
+    val totalComicPages: Int = 0,
+
+    // Initial scroll position to restore (set when loading a book with saved progress)
+    val initialScrollIndex: Int = -1,
+    val initialScrollOffset: Int = 0
 )


### PR DESCRIPTION
Fixes issue where saved progress displayed in library but book opened at beginning

ReaderModel tried to scroll using its internal LazyListState, but the UI uses a different LazyListState instance created with rememberSaveable. This caused books to open at the beginning instead of the saved progress position when the app was closed and reopened.

Changes:
- Add initialScrollIndex and initialScrollOffset to ReaderState
- Calculate scroll position in ReaderModel.init() and store in state
- Add LaunchedEffect in ReaderScreen to restore scroll position when text loads
- Make updateChapter() public so UI can update chapter after scrolling

