### PR TITLE
Improve chip editor UX, fix chip dialogs, and fix search race condition

### DIFF
--- a/app/src/main/java/us/blindmint/codex/presentation/book_info/BookInfoDetailsPanel.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/book_info/BookInfoDetailsPanel.kt
@@ -75,7 +75,10 @@ fun BookInfoDetailsPanel(
     val hasChanges = editedBook != null && (
         editedBook.title != book.title ||
         editedBook.authors != book.authors ||
-        editedBook.description != book.description
+        editedBook.description != book.description ||
+        editedBook.tags != book.tags ||
+        editedBook.series != book.series ||
+        editedBook.languages != book.languages
     )
 
     val cachedFile = remember(displayBook.filePath) {

--- a/app/src/main/java/us/blindmint/codex/presentation/book_info/BookInfoDialog.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/book_info/BookInfoDialog.kt
@@ -79,45 +79,39 @@ fun BookInfoDialog(
         }
 
         BookInfoScreen.TAGS_DIALOG -> {
-            if (editedBook != null) {
-                MetadataItemEditor(
-                    title = stringResource(id = R.string.tags),
-                    items = editedBook.tags,
-                    onItemsChanged = { newTags ->
-                        onUpdateEditedBook(editedBook.copy(tags = newTags))
-                        dismissDialog(BookInfoEvent.OnDismissDialog)
-                    },
-                    onDismiss = { dismissDialog(BookInfoEvent.OnDismissDialog) }
-                )
-            }
+            val base = editedBook ?: book
+            MetadataItemEditor(
+                title = stringResource(id = R.string.tags),
+                items = base.tags,
+                onItemsChanged = { newTags ->
+                    onUpdateEditedBook(base.copy(tags = newTags))
+                    dismissDialog(BookInfoEvent.OnDismissDialog)
+                }
+            )
         }
 
         BookInfoScreen.SERIES_DIALOG -> {
-            if (editedBook != null) {
-                MetadataItemEditor(
-                    title = stringResource(id = R.string.series),
-                    items = editedBook.series,
-                    onItemsChanged = { newSeries ->
-                        onUpdateEditedBook(editedBook.copy(series = newSeries))
-                        dismissDialog(BookInfoEvent.OnDismissDialog)
-                    },
-                    onDismiss = { dismissDialog(BookInfoEvent.OnDismissDialog) }
-                )
-            }
+            val base = editedBook ?: book
+            MetadataItemEditor(
+                title = stringResource(id = R.string.series),
+                items = base.series,
+                onItemsChanged = { newSeries ->
+                    onUpdateEditedBook(base.copy(series = newSeries))
+                    dismissDialog(BookInfoEvent.OnDismissDialog)
+                }
+            )
         }
 
         BookInfoScreen.LANGUAGES_DIALOG -> {
-            if (editedBook != null) {
-                MetadataItemEditor(
-                    title = stringResource(id = R.string.languages),
-                    items = editedBook.languages,
-                    onItemsChanged = { newLanguages ->
-                        onUpdateEditedBook(editedBook.copy(languages = newLanguages))
-                        dismissDialog(BookInfoEvent.OnDismissDialog)
-                    },
-                    onDismiss = { dismissDialog(BookInfoEvent.OnDismissDialog) }
-                )
-            }
+            val base = editedBook ?: book
+            MetadataItemEditor(
+                title = stringResource(id = R.string.languages),
+                items = base.languages,
+                onItemsChanged = { newLanguages ->
+                    onUpdateEditedBook(base.copy(languages = newLanguages))
+                    dismissDialog(BookInfoEvent.OnDismissDialog)
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/us/blindmint/codex/presentation/book_info/MetadataItemEditor.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/book_info/MetadataItemEditor.kt
@@ -8,23 +8,26 @@ package us.blindmint.codex.presentation.book_info
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,62 +35,81 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import us.blindmint.codex.R
-import us.blindmint.codex.presentation.core.components.common.LazyColumnWithScrollbar
 import us.blindmint.codex.presentation.core.components.modal_bottom_sheet.ModalBottomSheet
 import us.blindmint.codex.presentation.settings.components.SettingsSubcategoryTitle
 
 /**
- * Modal bottom sheet for editing a list of metadata items (tags, authors, series, languages).
- * Shows existing items with remove buttons and allows adding new items.
+ * Modal bottom sheet for editing a list of metadata items (tags, series, languages).
+ *
+ * Changes are committed when the sheet is dismissed — no explicit "Save" button required.
+ * Tapping X removes a chip immediately (no confirmation dialog). The keyboard Done action
+ * and the "+ Add" button both add the typed item.
+ *
+ * The chip list grows naturally for small sets. Once it would exceed ~55% of the screen
+ * height it becomes internally scrollable, keeping the drag handle and add section always
+ * visible.
  */
 @Composable
 fun MetadataItemEditor(
     title: String,
     items: List<String>,
     onItemsChanged: (List<String>) -> Unit,
-    onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var currentItems by remember { mutableStateOf(items) }
     var newItemText by remember { mutableStateOf("") }
-    var itemToRemove by remember { mutableStateOf<String?>(null) }
+
+    fun addItem() {
+        val trimmed = newItemText.trim()
+        if (trimmed.isNotBlank() && trimmed !in currentItems) {
+            currentItems = currentItems + trimmed
+            newItemText = ""
+        }
+    }
 
     ModalBottomSheet(
         modifier = modifier.fillMaxWidth(),
-        onDismissRequest = onDismiss,
+        onDismissRequest = { onItemsChanged(currentItems) },
         sheetGesturesEnabled = true
     ) {
-        LazyColumnWithScrollbar(
-            modifier = Modifier.fillMaxWidth(),
-            contentPadding = PaddingValues(bottom = 8.dp)
-        ) {
-            item {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    SettingsSubcategoryTitle(
-                        title = title,
-                        padding = 0.dp,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
+        val screenHeight = LocalConfiguration.current.screenHeightDp.dp
+        // Chips list grows freely up to ~55% of screen height, then scrolls internally.
+        // Header + add section occupy the rest, keeping total sheet well under ~85%.
+        val maxChipsHeight = screenHeight * 0.55f
+
+        Column(modifier = Modifier.fillMaxWidth()) {
+
+            // Title header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SettingsSubcategoryTitle(
+                    title = title,
+                    padding = 0.dp,
+                    color = MaterialTheme.colorScheme.primary
+                )
             }
 
-            // Display current items
-            currentItems.forEachIndexed { index, item ->
-                item {
+            // Chip list — grows naturally, scrollable once it hits maxChipsHeight
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = maxChipsHeight)
+            ) {
+                items(currentItems, key = { it }) { item ->
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                            .padding(horizontal = 16.dp, vertical = 4.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -96,12 +118,9 @@ fun MetadataItemEditor(
                             modifier = Modifier.weight(1f),
                             style = MaterialTheme.typography.bodyMedium
                         )
-
                         IconButton(
-                            onClick = {
-                                itemToRemove = item
-                            },
-                            modifier = Modifier.size(24.dp)
+                            onClick = { currentItems = currentItems - item },
+                            modifier = Modifier.size(40.dp)
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Close,
@@ -113,83 +132,40 @@ fun MetadataItemEditor(
                 }
             }
 
-            // Add new item section
-            item {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+            // Add section — always visible below the chip list
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedTextField(
+                    value = newItemText,
+                    onValueChange = { newItemText = it },
+                    label = { Text(stringResource(id = R.string.add_new)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Words,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(onDone = { addItem() }),
+                    singleLine = true
+                )
+
+                Button(
+                    onClick = { addItem() },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = newItemText.trim().isNotBlank()
                 ) {
-                    OutlinedTextField(
-                        value = newItemText,
-                        onValueChange = { newItemText = it },
-                        label = { Text(stringResource(id = R.string.add_new)) },
-                        modifier = Modifier.fillMaxWidth(),
-                        keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Words),
-                        singleLine = true
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp)
                     )
-
-                    Button(
-                        onClick = {
-                            val trimmedText = newItemText.trim()
-                            if (trimmedText.isNotBlank() && !currentItems.contains(trimmedText)) {
-                                currentItems = currentItems + trimmedText
-                                newItemText = ""
-                            }
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp),
-                        enabled = newItemText.trim().isNotBlank()
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Add,
-                            contentDescription = null,
-                            modifier = Modifier
-                                .size(20.dp)
-                                .padding(end = 8.dp)
-                        )
-                        Text(stringResource(id = R.string.add))
-                    }
-
-                    // Save button
-                    Button(
-                        onClick = {
-                            onItemsChanged(currentItems)
-                            onDismiss()
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 8.dp)
-                    ) {
-                        Text(stringResource(id = R.string.save_changes))
-                    }
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(stringResource(id = R.string.add))
                 }
             }
         }
-    }
-
-    if (itemToRemove != null) {
-        AlertDialog(
-            onDismissRequest = { itemToRemove = null },
-            title = { Text(stringResource(id = R.string.remove_item)) },
-            text = { Text(stringResource(id = R.string.confirm_remove_item, itemToRemove ?: "")) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        currentItems = currentItems.filter { it != itemToRemove }
-                        itemToRemove = null
-                    }
-                ) {
-                    Text(stringResource(id = R.string.delete))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { itemToRemove = null }) {
-                    Text(stringResource(id = R.string.cancel))
-                }
-            }
-        )
     }
 }

--- a/app/src/main/java/us/blindmint/codex/presentation/core/constants/AboutBadgeConstants.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/core/constants/AboutBadgeConstants.kt
@@ -15,7 +15,7 @@ fun provideAboutBadges() = listOf(
         drawable = R.drawable.github,
         imageVector = null,
         contentDescription = R.string.github_badge,
-        url = "https://www.github.com/BlindMint"
+        url = "https://github.com/BlindMint/codex"
     ),
     Badge(
         id = "gitlab",
@@ -29,6 +29,6 @@ fun provideAboutBadges() = listOf(
         drawable = R.drawable.codeberg,
         imageVector = null,
         contentDescription = R.string.codeberg_badge,
-        url = "https://www.codeberg.org/BlindMint"
+        url = "https://codeberg.org/BlindMint/codex"
     ),
 )

--- a/app/src/main/java/us/blindmint/codex/presentation/library/BulkEditBottomSheet.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/library/BulkEditBottomSheet.kt
@@ -263,8 +263,7 @@ fun BulkEditBottomSheet(
             onItemsChanged = { tags ->
                 pendingTags = tags
                 showTagsEditor = false
-            },
-            onDismiss = { showTagsEditor = false }
+            }
         )
     }
 
@@ -275,8 +274,7 @@ fun BulkEditBottomSheet(
             onItemsChanged = { series ->
                 pendingSeries = series
                 showSeriesEditor = false
-            },
-            onDismiss = { showSeriesEditor = false }
+            }
         )
     }
 
@@ -287,8 +285,7 @@ fun BulkEditBottomSheet(
             onItemsChanged = { languages ->
                 pendingLanguages = languages
                 showLanguagesEditor = false
-            },
-            onDismiss = { showLanguagesEditor = false }
+            }
         )
     }
 
@@ -299,8 +296,7 @@ fun BulkEditBottomSheet(
             onItemsChanged = { authors ->
                 pendingAuthors = authors
                 showAuthorsEditor = false
-            },
-            onDismiss = { showAuthorsEditor = false }
+            }
         )
     }
 }

--- a/app/src/main/java/us/blindmint/codex/presentation/settings/SettingsItem.kt
+++ b/app/src/main/java/us/blindmint/codex/presentation/settings/SettingsItem.kt
@@ -6,23 +6,11 @@
 
 package us.blindmint.codex.presentation.settings
 
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.graphics.vector.ImageVector
 
 /**
- * Data class representing a main settings menu item
- *
- * @deprecated Use [Preference.PreferenceItem] with [PreferenceScreen] instead.
- * This class is kept for backward compatibility and will be removed in future versions.
+ * Data class representing a main settings menu item (Appearance, Reader, Library, etc.).
+ * Used by [SettingsLayout] and [FuzzySearchHelper] for the top-level settings navigation.
  */
-@Deprecated(
-    message = "Use Preference.PreferenceItem with PreferenceScreen instead",
-    replaceWith = ReplaceWith(
-        "Preference.PreferenceItem",
-        imports = ["us.blindmint.codex.presentation.settings.Preference"]
-    ),
-    level = DeprecationLevel.WARNING
-)
 data class SettingsItem(
     val id: String,
     val title: String,

--- a/app/src/main/java/us/blindmint/codex/ui/library/LibraryModel.kt
+++ b/app/src/main/java/us/blindmint/codex/ui/library/LibraryModel.kt
@@ -150,22 +150,27 @@ class LibraryModel @Inject constructor(
                         )
                     }
                     searchQueryChange?.cancel()
-                    searchQueryChange = launch(Dispatchers.IO) {
-                        delay(500)
-                        yield()
-                        onEvent(LibraryEvent.OnSearch)
+                    refreshJob?.cancel() // prevent stale in-flight search from writing results
+                    if (event.query.isBlank()) {
+                        // Empty query: skip debounce, load all books immediately
+                        refreshJob = launch(Dispatchers.IO) { getBooksFromDatabase() }
+                    } else {
+                        searchQueryChange = launch(Dispatchers.IO) {
+                            delay(500)
+                            yield()
+                            onEvent(LibraryEvent.OnSearch)
+                        }
                     }
                 }
             }
 
             is LibraryEvent.OnSearch -> {
-                viewModelScope.launch(Dispatchers.IO) {
-                    onEvent(
-                        LibraryEvent.OnRefreshList(
-                            loading = false,
-                            hideSearch = false
-                        )
-                    )
+                // Bypass OnRefreshList entirely so isRefreshing is never set.
+                // The debounce in OnSearchQueryChange covers the processing delay;
+                // results then appear via animateItem() with no spinner.
+                refreshJob?.cancel()
+                refreshJob = viewModelScope.launch(Dispatchers.IO) {
+                    getBooksFromDatabase()
                 }
             }
 


### PR DESCRIPTION
- MetadataItemEditor: remove Save button and per-chip confirmation dialogs; chips are removed immediately on X, changes auto-commit on sheet dismiss, keyboard Done action adds item, layout capped at 55% screen height so add section is always visible
- BookInfoDialog: fix Tags/Series/Languages dialogs never opening when editedBook is null; use editedBook ?: book pattern
- BookInfoDetailsPanel: include tags/series/languages in hasChanges check so confirm/cancel buttons appear for chip-only edits
- BulkEditBottomSheet: remove onDismiss parameter from MetadataItemEditor call sites (removed in editor rewrite)
- SettingsItem: remove premature @Deprecated annotation (was causing all build warnings)
- LibraryModel: fix search backspace race condition — cancel in-flight refreshJob on every query change; bypass debounce and load all books immediately when query is cleared